### PR TITLE
Repeating actions and major additions

### DIFF
--- a/clicker/MainWindow.xaml
+++ b/clicker/MainWindow.xaml
@@ -5,15 +5,15 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Clicker"
         mc:Ignorable="d"
-        Title="Clicker" SizeToContent="Width" Height="299" Width="445.667">
-    <Grid>
-        
+        Title="Clicker" SizeToContent="Width" Height="346.37" Width="368.067">
+    <Grid Margin="0,0,-0.4,12">
+
         <Grid.RowDefinitions>
-            <RowDefinition Height="1*"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="50"/>
         </Grid.RowDefinitions>
         <ScrollViewer HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Auto">
-            <DataGrid Name="dataGrid" ItemsSource="{Binding MouseActions.Actions, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" IsReadOnly="{Binding MouseActions.IsRunning, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" >
+            <DataGrid Name="dataGrid" ItemsSource="{Binding MouseActions.Actions, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" IsReadOnly="{Binding MouseActions.IsRunning, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" Height="236" >
                 <DataGrid.RowStyle>
                     <Style TargetType="DataGridRow">
                         <Style.Triggers>
@@ -31,7 +31,7 @@
                 </DataGrid.RowStyle>
             </DataGrid>
         </ScrollViewer>
-        <StackPanel Orientation="Vertical" Grid.Row="1" VerticalAlignment="Bottom" Height="50">
+        <StackPanel Orientation="Vertical" VerticalAlignment="Bottom" Height="50" Margin="0,0,0.2,0" Grid.RowSpan="2">
             <TextBlock Margin="8,3,0,0"><Run Text="Middle click to record a new click."/></TextBlock>
             <StackPanel Orientation="Horizontal" Margin="3,3,0,0">
                 <Button Content="Run"   Click="RunButton"   IsEnabled="{Binding MouseActions.CanRunOrClear, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" Margin="3,3,0,3" Width="60" />
@@ -39,8 +39,13 @@
                 <Button Content="Stop"  Click="StopButton"  IsEnabled="{Binding MouseActions.CanRequestStop, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" Margin="3,3,0,3" Width="60" />
                 <Button Content="Reset"  Click="ResetButton"  Margin="3,3,0,3" Width="60" />
                 <CheckBox x:Name="AutorunCheckbox" Content="Autorun" Height="18" Width="65" Margin="30,0,0,0" Click="AutorunCheckbox_Click" />
-                <CheckBox x:Name="PausedCheckbox" Content="Paused" Height="18" Width="61" Margin="30,0,0,0" Click="AutorunCheckbox_Click" />
             </StackPanel>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="3,50.2,0.6,-22.8" RenderTransformOrigin="0.5,0.5" Grid.Row="1">
+            <Label x:Name="label" Content="Step Action:" Width="66" Margin="0,0,0,0.2" FontSize="10"/>
+            <TextBox x:Name="TextBox" TextWrapping="Wrap" Width="124" Height="19" VerticalAlignment="Center" FontSize="12" KeyDown="TextBox_KeyPress" Margin="0,2,0,2.2" RenderTransformOrigin="0.515,-0.278" />
+            <Button Content="Go"  Click="GoToStepButton"  Margin="3,2,0,2" Width="60" />
+            <CheckBox x:Name="PausedCheckbox" Content="Paused" Width="70" Margin="30,2,0,2.2" Click="PausedCheckbox_Click" RenderTransformOrigin="-1.316,2.422" />
         </StackPanel>
     </Grid>
 </Window>

--- a/clicker/MainWindow.xaml
+++ b/clicker/MainWindow.xaml
@@ -5,22 +5,41 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Clicker"
         mc:Ignorable="d"
-        Title="Clicker" SizeToContent="Width" Height="299" Width="391">
+        Title="Clicker" SizeToContent="Width" Height="299" Width="445.667">
     <Grid>
+        
         <Grid.RowDefinitions>
             <RowDefinition Height="1*"/>
             <RowDefinition Height="50"/>
         </Grid.RowDefinitions>
         <ScrollViewer HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Auto">
-            <DataGrid ItemsSource="{Binding MouseActions.Actions, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" IsReadOnly="{Binding MouseActions.IsRunning, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" />
+            <DataGrid Name="dataGrid" ItemsSource="{Binding MouseActions.Actions, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" IsReadOnly="{Binding MouseActions.IsRunning, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" >
+                <DataGrid.RowStyle>
+                    <Style TargetType="DataGridRow">
+                        <Style.Triggers>
+                            <Trigger Property="IsSelected"
+                        Value="True">
+                                <Setter Property="BorderBrush"
+                        Value="Yellow" />
+                                <Setter Property="BorderThickness"
+                        Value="2" />
+                                <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>
+
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </DataGrid.RowStyle>
+            </DataGrid>
         </ScrollViewer>
-        <StackPanel Orientation="Vertical" Grid.Row="1" VerticalAlignment="Bottom" Height="73" Margin="0,0,0,-23">
+        <StackPanel Orientation="Vertical" Grid.Row="1" VerticalAlignment="Bottom" Height="50">
             <TextBlock Margin="8,3,0,0"><Run Text="Middle click to record a new click."/></TextBlock>
             <StackPanel Orientation="Horizontal" Margin="3,3,0,0">
                 <Button Content="Run"   Click="RunButton"   IsEnabled="{Binding MouseActions.CanRunOrClear, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" Margin="3,3,0,3" Width="60" />
                 <Button Content="Clear" Click="ClearButton" IsEnabled="{Binding MouseActions.CanRunOrClear, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" Margin="3,3,0,3" Width="60" />
                 <Button Content="Stop"  Click="StopButton"  IsEnabled="{Binding MouseActions.CanRequestStop, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" Margin="3,3,0,3" Width="60" />
-                <CheckBox x:Name="AutorunCheckbox" Content="Autorun" Height="18" Width="94" Margin="30,0,0,0" Click="AutorunCheckbox_Click" />
+                <Button Content="Reset"  Click="ResetButton"  Margin="3,3,0,3" Width="60" />
+                <CheckBox x:Name="AutorunCheckbox" Content="Autorun" Height="18" Width="65" Margin="30,0,0,0" Click="AutorunCheckbox_Click" />
+                <CheckBox x:Name="PausedCheckbox" Content="Paused" Height="18" Width="61" Margin="30,0,0,0" Click="AutorunCheckbox_Click" />
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/clicker/MainWindow.xaml
+++ b/clicker/MainWindow.xaml
@@ -13,18 +13,14 @@
             <RowDefinition Height="50"/>
         </Grid.RowDefinitions>
         <ScrollViewer HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Auto">
-            <DataGrid Name="dataGrid" ItemsSource="{Binding MouseActions.Actions, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" IsReadOnly="{Binding MouseActions.IsRunning, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" Height="236" >
+            <DataGrid Name="DataGrid" ItemsSource="{Binding MouseActions.Actions, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" IsReadOnly="{Binding MouseActions.IsRunning, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" Height="236" >
                 <DataGrid.RowStyle>
                     <Style TargetType="DataGridRow">
                         <Style.Triggers>
-                            <Trigger Property="IsSelected"
-                        Value="True">
-                                <Setter Property="BorderBrush"
-                        Value="Yellow" />
-                                <Setter Property="BorderThickness"
-                        Value="2" />
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter Property="BorderBrush" Value="Yellow" />
+                                <Setter Property="BorderThickness" Value="2" />
                                 <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>
-
                             </Trigger>
                         </Style.Triggers>
                     </Style>

--- a/clicker/MainWindow.xaml
+++ b/clicker/MainWindow.xaml
@@ -13,7 +13,7 @@
             <RowDefinition Height="50"/>
         </Grid.RowDefinitions>
         <ScrollViewer HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Auto">
-            <DataGrid Name="DataGrid" ItemsSource="{Binding MouseActions.Actions, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" IsReadOnly="{Binding MouseActions.IsRunning, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" Height="236" >
+            <DataGrid Name="DataGrid" ItemsSource="{Binding MouseActions.Actions, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" IsReadOnly="{Binding MouseActions.Editable, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" Height="236" >
                 <DataGrid.RowStyle>
                     <Style TargetType="DataGridRow">
                         <Style.Triggers>

--- a/clicker/MainWindow.xaml.cs
+++ b/clicker/MainWindow.xaml.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Forms;
-using System.Windows.Input;
 using MouseKeyboardActivityMonitor;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -41,8 +40,8 @@ namespace Clicker
                 {
                     App.Current?.Dispatcher.Invoke(() =>
                     {
-                        this.dataGrid.SelectedIndex = RuntimeSettings.Step;
-                        this.dataGrid.ScrollIntoView(this.dataGrid.Items.GetItemAt(RuntimeSettings.Step));
+                        this.DataGrid.SelectedIndex = RuntimeSettings.Step;
+                        this.DataGrid.ScrollIntoView(this.DataGrid.Items.GetItemAt(RuntimeSettings.Step));
                         this.TextBox.Text ="" + RuntimeSettings.Step;
                     });
                 }
@@ -138,8 +137,8 @@ namespace Clicker
 
         private void ResetButton(object sender, RoutedEventArgs e) { 
             RuntimeSettings.Step = 0; 
-            this.dataGrid.SelectedIndex = RuntimeSettings.Step;
-            this.dataGrid.ScrollIntoView(this.dataGrid.Items.GetItemAt(RuntimeSettings.Step));
+            this.DataGrid.SelectedIndex = RuntimeSettings.Step;
+            this.DataGrid.ScrollIntoView(this.DataGrid.Items.GetItemAt(RuntimeSettings.Step));
         }
 
         private void StopButton(object sender, RoutedEventArgs e) { MouseActions.IsStopRequested = true; }

--- a/clicker/MainWindow.xaml.cs
+++ b/clicker/MainWindow.xaml.cs
@@ -21,14 +21,15 @@ namespace Clicker
         {
             InitializeComponent();
 
-            MouseActions = new MouseActionViewModel();
-            Settings = new Settings();
+            Settings = new Settings();           
 
             if (File.Exists(Settings.SettingsFilename))
             {
                 Settings = JsonConvert.DeserializeObject<Settings>(File.ReadAllText(Settings.SettingsFilename));
                 AutorunCheckbox.IsChecked = Settings.Autorun;
             }
+
+            MouseActions = new MouseActionViewModel(Settings);
 
             if (File.Exists(Settings.AutosaveFilename))
             {
@@ -64,7 +65,16 @@ namespace Clicker
                 }
             };
 
-            App.Current.Exit += (object sender, ExitEventArgs e) =>
+            M.MouseDoubleClick += (object s, System.Windows.Forms.MouseEventArgs e) =>
+            {
+                if (e.Button == System.Windows.Forms.MouseButtons.Right)
+                {
+                    Settings.Autorun = false;
+                    AutorunCheckbox.IsChecked = Settings.Autorun;
+                }
+            };
+
+           App.Current.Exit += (object sender, ExitEventArgs e) =>
             {
                 MouseActions.IsStopRequested = true;
                 M?.Stop();

--- a/clicker/MainWindow.xaml.cs
+++ b/clicker/MainWindow.xaml.cs
@@ -84,6 +84,7 @@ namespace Clicker
                     else {
                         if (RuntimeSettings.Pause)
                         {
+                            RuntimeSettings.Step += 1;
                             MouseActions.Actions.Insert(RuntimeSettings.Step, new Action(MouseActions.Actions.Count,
                                 e.X,
                                 e.Y,
@@ -133,7 +134,7 @@ namespace Clicker
 
         private void ClearButton(object sender, RoutedEventArgs e) { MouseActions.Actions.Clear(); TextBox.Text = ""; }
 
-        private void RunButton(object sender, RoutedEventArgs e) { MouseActions.RunActions(); }
+        private void RunButton(object sender, RoutedEventArgs e) { RuntimeSettings.Step = 0; MouseActions.RunActions(); }
 
         private void ResetButton(object sender, RoutedEventArgs e) { 
             RuntimeSettings.Step = 0; 
@@ -146,6 +147,9 @@ namespace Clicker
         private void GoToStepButton(object sender, RoutedEventArgs e) { 
             try {
                 RuntimeSettings.Step = Int32.Parse(TextBox.Text);
+                if (!MouseActions.IsRunning) {
+                    MouseActions.RunActions();
+                }
             } catch (Exception exception) {
                 TextBox.Text = exception.Message;
             }

--- a/clicker/MainWindow.xaml.cs
+++ b/clicker/MainWindow.xaml.cs
@@ -17,7 +17,7 @@ namespace Clicker
     {
         public MouseActionViewModel MouseActions { get; set; }
         public Settings Settings { get; set; }
-        public RuntimeSettings RuntimeSettings { get; set; }
+        private RuntimeSettings RuntimeSettings;
         MouseHookListener M;
 
         public MainWindow()

--- a/clicker/MainWindow.xaml.cs
+++ b/clicker/MainWindow.xaml.cs
@@ -27,13 +27,6 @@ namespace Clicker
             Settings = new Settings();
             RuntimeSettings = new RuntimeSettings();
 
-            RuntimeSettings.StepChanged += (object sender, EventArgs args) => {
-                // sender?.Invoke();
-
-                this.dataGrid.SelectedIndex = MouseActions.Actions.Count;
-                this.dataGrid.ScrollIntoView(this.dataGrid.Items.GetItemAt(MouseActions.Actions.Count));
-            };
-
             if (File.Exists(Settings.SettingsFilename))
             {
                 Settings = JsonConvert.DeserializeObject<Settings>(File.ReadAllText(Settings.SettingsFilename));
@@ -41,6 +34,17 @@ namespace Clicker
             }
 
             MouseActions = new MouseActionViewModel(Settings, RuntimeSettings);
+
+            RuntimeSettings.StepChanged += (object sender, EventArgs args) => {
+                if (RuntimeSettings.Step < MouseActions.Actions.Count)
+                {
+                    App.Current?.Dispatcher.Invoke(() =>
+                    {
+                        this.dataGrid.SelectedIndex = RuntimeSettings.Step;
+                        this.dataGrid.ScrollIntoView(this.dataGrid.Items.GetItemAt(RuntimeSettings.Step));
+                    });
+                }
+            };
 
             if (File.Exists(Settings.AutosaveFilename))
             {

--- a/clicker/MainWindow.xaml.cs
+++ b/clicker/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Forms;
 using System.Windows.Input;
 using MouseKeyboardActivityMonitor;
 using Newtonsoft.Json;
@@ -42,6 +43,7 @@ namespace Clicker
                     {
                         this.dataGrid.SelectedIndex = RuntimeSettings.Step;
                         this.dataGrid.ScrollIntoView(this.dataGrid.Items.GetItemAt(RuntimeSettings.Step));
+                        this.TextBox.Text ="" + RuntimeSettings.Step;
                     });
                 }
             };
@@ -130,21 +132,40 @@ namespace Clicker
             }
         }
 
-        private void ClearButton(object sender, RoutedEventArgs e) { MouseActions.Actions.Clear(); }
+        private void ClearButton(object sender, RoutedEventArgs e) { MouseActions.Actions.Clear(); TextBox.Text = ""; }
 
         private void RunButton(object sender, RoutedEventArgs e) { MouseActions.RunActions(); }
 
-        private void ResetButton(object sender, RoutedEventArgs e) { RuntimeSettings.Reset = true; }
+        private void ResetButton(object sender, RoutedEventArgs e) { 
+            RuntimeSettings.Step = 0; 
+            this.dataGrid.SelectedIndex = RuntimeSettings.Step;
+            this.dataGrid.ScrollIntoView(this.dataGrid.Items.GetItemAt(RuntimeSettings.Step));
+        }
 
         private void StopButton(object sender, RoutedEventArgs e) { MouseActions.IsStopRequested = true; }
+
+        private void GoToStepButton(object sender, RoutedEventArgs e) { 
+            try {
+                RuntimeSettings.Step = Int32.Parse(TextBox.Text);
+            } catch (Exception exception) {
+                TextBox.Text = exception.Message;
+            }
+        }
 
         private void AutorunCheckbox_Click(object sender, RoutedEventArgs e)
         {
             Settings.Autorun = AutorunCheckbox.IsChecked ?? false;
         }
-        private void PauseCkeckbox_Click(object sender, RoutedEventArgs e)
+        private void PausedCheckbox_Click(object sender, RoutedEventArgs e)
         {
             RuntimeSettings.Pause = PausedCheckbox.IsChecked ?? false;
+        }
+
+        private void TextBox_KeyPress(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (System.Text.RegularExpressions.Regex.IsMatch(e.Key.ToString(), "[0-9]"))
+                e.Handled = false;
+            else e.Handled = true;
         }
 
     }

--- a/clicker/MouseAction.cs
+++ b/clicker/MouseAction.cs
@@ -8,6 +8,7 @@ namespace Clicker
     /// </summary>
     public partial class Action
     {
+        public int Index { get; set; }
         /// <summary>
         /// Horizonal position of mouse cursor.
         /// </summary>
@@ -38,8 +39,9 @@ namespace Clicker
         /// <param name="xPosition">Horizonal position of mouse cursor</param>
         /// <param name="yPosition">Vertical position of mouse cursor</param>
         /// <param name="cooldown">Time to wait after performing action</param>
-        public Action(int xPosition, int yPosition, TimeSpan cooldown, ClickType button = ClickType.LeftClick, ActionType type = ActionType.Click, string text = null)
+        public Action(int index, int xPosition, int yPosition, TimeSpan cooldown, ClickType button = ClickType.LeftClick, ActionType type = ActionType.Click, string text = null)
         {
+            Index = index;
             XPosition = xPosition;
             YPosition = yPosition;
             Cooldown = cooldown;

--- a/clicker/MouseActionViewModel.cs
+++ b/clicker/MouseActionViewModel.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Threading;
-using System.Windows.Controls;
-using MouseKeyboardActivityMonitor;
 
 namespace Clicker
 {

--- a/clicker/MouseActionViewModel.cs
+++ b/clicker/MouseActionViewModel.cs
@@ -26,6 +26,12 @@ namespace Clicker
             }
         }
 
+        public bool Editable {
+            get {
+                return !((IsRunning && RuntimeSettings.Pause) || !IsRunning); 
+            }
+        }
+
         bool _isRunning = false;
 
         /// <summary>
@@ -99,7 +105,6 @@ namespace Clicker
             {
                 do
                 {
-                    RuntimeSettings.Step = 0;
                     while (RuntimeSettings.Step < Actions.Count && !IsStopRequested)
                     {
                         Action ma = Actions[RuntimeSettings.Step];

--- a/clicker/MouseActionViewModel.cs
+++ b/clicker/MouseActionViewModel.cs
@@ -120,10 +120,10 @@ namespace Clicker
                     App.Current?.Dispatcher.Invoke(() =>
                     {
                         IsRunning = false;
-
                         IsStopRequested = false;
+                        RuntimeSettings.Step = 0;
                     });
-
+                    
                 } while (Settings.Autorun);
             });
 

--- a/clicker/MouseActionViewModel.cs
+++ b/clicker/MouseActionViewModel.cs
@@ -118,10 +118,6 @@ namespace Clicker
                         {
                             System.Threading.Thread.Sleep(1000);
                         }
-                        if (RuntimeSettings.Reset) {
-                            RuntimeSettings.Step = 0;
-                            RuntimeSettings.Reset = false;
-                        }
                     }
 
                     App.Current?.Dispatcher.Invoke(() =>

--- a/clicker/MouseActionViewModel.cs
+++ b/clicker/MouseActionViewModel.cs
@@ -122,14 +122,15 @@ namespace Clicker
                         }
                     }
 
-                    App.Current?.Dispatcher.Invoke(() =>
-                    {
-                        IsRunning = false;
-                        IsStopRequested = false;
-                        RuntimeSettings.Step = 0;
-                    });
+                    RuntimeSettings.Step = 0;
                     
-                } while (Settings.Autorun);
+                } while (Settings.Autorun && !IsStopRequested);
+
+                App.Current?.Dispatcher.Invoke(() =>
+                {
+                    IsRunning = false;
+                    IsStopRequested = false;
+                });
             });
 
             t.Start();

--- a/clicker/RuntimeSettings.cs
+++ b/clicker/RuntimeSettings.cs
@@ -23,7 +23,6 @@ namespace Clicker
                 OnStepChanged(EventArgs.Empty);
             }
         }
-        public bool Reset { get; set; }
 
         public delegate void StepChangedEventHandler(object source, EventArgs args);
         public event EventHandler StepChanged;
@@ -32,7 +31,6 @@ namespace Clicker
         {
             Pause = false;
             _step = 0;
-            Reset = false;
         }
 
         protected virtual void OnStepChanged(EventArgs e)

--- a/clicker/RuntimeSettings.cs
+++ b/clicker/RuntimeSettings.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+
+namespace Clicker
+{
+    
+    public class RuntimeSettings
+    {
+        private int _step;
+        public bool Pause { get; set; }
+        public int Step {
+            get
+            {
+                return _step;                
+            }
+            set
+            {
+                if (_step == value) return;
+                _step = value;
+
+                OnStepChanged();
+            }
+        }
+        public bool Reset { get; set; }
+
+        public delegate void StepChangedEventHandler(object source, EventArgs args);
+        public event EventHandler StepChanged;
+
+        public RuntimeSettings()
+        {
+            Pause = false;
+            _step = 0;
+            Reset = false;
+        }
+
+        protected virtual void OnStepChanged()
+        {
+            if (StepChanged != null) {
+                StepChanged(StepChanged, EventArgs.Empty);
+            }
+        }
+    }
+}

--- a/clicker/RuntimeSettings.cs
+++ b/clicker/RuntimeSettings.cs
@@ -19,10 +19,8 @@ namespace Clicker
             }
             set
             {
-                if (_step == value) return;
                 _step = value;
-
-                OnStepChanged();
+                OnStepChanged(EventArgs.Empty);
             }
         }
         public bool Reset { get; set; }
@@ -37,11 +35,9 @@ namespace Clicker
             Reset = false;
         }
 
-        protected virtual void OnStepChanged()
+        protected virtual void OnStepChanged(EventArgs e)
         {
-            if (StepChanged != null) {
-                StepChanged(StepChanged, EventArgs.Empty);
-            }
+            StepChanged?.Invoke(this, e);
         }
     }
 }

--- a/clicker/Settings.cs
+++ b/clicker/Settings.cs
@@ -12,6 +12,7 @@ namespace Clicker
         public string AutosaveFilename { get; set; }
         public string SettingsFilename { get; set; }
         public TimeSpan DefaultCooldown { get; set; }
+        
 
         public Settings()
         {

--- a/clicker/clicker.csproj
+++ b/clicker/clicker.csproj
@@ -83,6 +83,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="RuntimeSettings.cs" />
     <Compile Include="Settings.cs" />
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>


### PR DESCRIPTION
This PR adds some new functionalities that helps the creation of sets of mouse actions.

Changes Proposed
 - New pause checkbox: A pause checkbox was added to allow pausing the mouse actions loop, giving back the control to the user. The user can also pause the execution is right double clicking with the mouse.
- Reset button: Restart the loop execution to the first mouse action.
- Add an action in the middle of a paused execution: Allows adding a new action before the current step when pause checkbox is checked.
- Go to an action: While on execution, go to an especific action and continue the execution from there.

Interface Improvements
- Index Collumn: Added a index collumn to show the user which action is executing right now.
- Highlight current step: Put a yellow border around the row related to the current mouse execution step.

Bug fixes
 - Working autorun: Autorun now executes a set of mouse actions indefinetely